### PR TITLE
Add build folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.idea
 *.iml
 /build-*
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,23 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_STANDARD 99)
 project(parallel-rsp LANGUAGES CXX C)
 
+
+set(NAME_PLUGIN_M64P "mupen64plus-rsp-parallel")
+
+include_directories(../mupen64plus-core/src/api)
+add_definitions(-DM64P_PLUGIN_API)
+add_definitions(-DPARALLEL_INTEGRATION)
+
 if (CMAKE_COMPILER_IS_GNUCXX OR (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))
     set(PARALLEL_RSP_CXX_FLAGS -Wall -Wextra -Wno-missing-field-initializers -Wno-empty-body -ffast-math -Wno-unused-parameter)
 elseif (MSVC)
     set(PARALLEL_RSP_CXX_FLAGS /D_CRT_SECURE_NO_WARNINGS /wd4267 /wd4244 /wd4309 /wd4005 /MP /DNOMINMAX)
 endif()
 
-add_library(parallel-rsp STATIC
+add_library(${NAME_PLUGIN_M64P} SHARED
+#		main.cpp
+		parallel.cpp
+#		debug_rsp.cpp
 		rsp/vfunctions.cpp
 		rsp_jit.cpp rsp_jit.hpp
 		jit_allocator.cpp jit_allocator.hpp
@@ -49,24 +59,26 @@ add_library(parallel-rsp STATIC
 		arch/simd/rsp/vxor.h
 		arch/simd/rsp/vmulm.h)
 
-option(PARALLEL_RSP_DEBUG_JIT "Enable the debug JIT." ON)
+option(PARALLEL_RSP_DEBUG_JIT "Enable the debug JIT." OFF)
 
 if (PARALLEL_RSP_DEBUG_JIT)
 	if (ANDROID)
 		message("Android does not support debug JIT. Disabling it.")
 	elseif (NOT WIN32)
-		target_sources(parallel-rsp PRIVATE debug_rsp.cpp debug_rsp.hpp debug_jit.cpp debug_jit.hpp)
-		target_compile_definitions(parallel-rsp PUBLIC PARALLEL_RSP_DEBUG_JIT)
+		target_sources(${NAME_PLUGIN_M64P} PRIVATE debug_rsp.cpp debug_rsp.hpp debug_jit.cpp debug_jit.hpp)
+		target_compile_definitions(${NAME_PLUGIN_M64P} PUBLIC PARALLEL_RSP_DEBUG_JIT)
 	endif()
 endif()
 
-target_include_directories(parallel-rsp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(parallel-rsp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/arch/simd/rsp)
-target_compile_options(parallel-rsp PRIVATE ${PARALLEL_RSP_CXX_FLAGS})
+set_target_properties(${NAME_PLUGIN_M64P} PROPERTIES PREFIX "")
+target_include_directories(${NAME_PLUGIN_M64P} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${NAME_PLUGIN_M64P} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/arch/simd/rsp)
+target_include_directories(${NAME_PLUGIN_M64P} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/api)
+target_compile_options(${NAME_PLUGIN_M64P} PRIVATE ${PARALLEL_RSP_CXX_FLAGS})
 
 option(PARALLEL_RSP_BAKED_LIGHTNING "Use built-in Lightning." ON)
 
-target_compile_definitions(parallel-rsp PUBLIC PARALLEL_RSP_LIGHTNING)
+target_compile_definitions(${NAME_PLUGIN_M64P} PUBLIC PARALLEL_RSP_LIGHTNING)
 if (PARALLEL_RSP_BAKED_LIGHTNING)
 	add_library(lightning STATIC
 			lightning/lib/jit_disasm.c
@@ -76,6 +88,7 @@ if (PARALLEL_RSP_BAKED_LIGHTNING)
 			lightning/lib/jit_print.c
 			lightning/lib/jit_size.c
 			lightning/lib/lightning.c)
+	set_property(TARGET lightning PROPERTY POSITION_INDEPENDENT_CODE ON)
 	target_include_directories(lightning PUBLIC
 			${CMAKE_CURRENT_SOURCE_DIR}/lightning/include)
 	if (WIN32)
@@ -83,120 +96,4 @@ if (PARALLEL_RSP_BAKED_LIGHTNING)
 		target_include_directories(lightning PRIVATE win32/mman)
 	endif()
 endif()
-target_link_libraries(parallel-rsp PUBLIC lightning)
-target_compile_definitions(parallel-rsp PUBLIC DEBUG_JIT)
-
-if (NOT WIN32)
-	target_link_libraries(parallel-rsp PRIVATE dl)
-endif()
-
-add_executable(rsp-runner main.cpp)
-target_link_libraries(rsp-runner PRIVATE parallel-rsp)
-target_compile_options(rsp-runner PRIVATE ${PARALLEL_RSP_CXX_FLAGS})
-
-if (PARALLEL_RSP_DEBUG_JIT AND NOT WIN32)
-	set_target_properties(rsp-runner PROPERTIES LINK_FLAGS "-rdynamic")
-endif()
-
-option(PARALLEL_RSP_TESTS "Enable unit tests for Lightning CPU." ON)
-
-add_executable(rsp-vu-fuzzer rsp_vu_fuzzer.cpp)
-target_link_libraries(rsp-vu-fuzzer PRIVATE parallel-rsp)
-target_compile_options(rsp-vu-fuzzer PRIVATE ${PARALLEL_RSP_CXX_FLAGS})
-
-if (PARALLEL_RSP_TESTS)
-	enable_testing()
-
-	if (ANDROID)
-		add_test(NAME rsp-vu-fuzz
-				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/android_fuzz_runner.sh
-				${CMAKE_CURRENT_BINARY_DIR}/rsp-vu-fuzzer)
-	else()
-		add_test(NAME rsp-vu-fuzz COMMAND $<TARGET_FILE:rsp-vu-fuzzer>)
-	endif()
-	add_custom_target(rsp-tests ALL)
-
-	add_custom_target(rsp-test-crt
-			COMMAND ${CMAKE_MAKE_PROGRAM} crt-obj -j1
-			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain)
-
-	function(rsp_add_test NAME)
-		add_custom_target(rsp-test-binary-${NAME}
-				COMMAND ${CMAKE_MAKE_PROGRAM} RSP_TEST=${NAME} -j1
-				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain
-				DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain/${NAME}.s)
-		add_dependencies(rsp-test-binary-${NAME} rsp-test-crt)
-		add_dependencies(rsp-tests rsp-test-binary-${NAME})
-
-		if (ANDROID)
-			add_test(NAME rsp-test-${NAME}
-					COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/android_test_runner.sh
-					${CMAKE_CURRENT_BINARY_DIR}/rsp-runner
-					${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain ${NAME})
-		else()
-			add_test(NAME rsp-test-${NAME}
-					COMMAND $<TARGET_FILE:rsp-runner>
-					${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain/${NAME}.global.bin
-					${CMAKE_CURRENT_SOURCE_DIR}/debug-toolchain/${NAME}.bin)
-		endif()
-	endfunction()
-
-	rsp_add_test(sll)
-	rsp_add_test(srl)
-	rsp_add_test(sra)
-	rsp_add_test(sllv)
-	rsp_add_test(srlv)
-	rsp_add_test(srav)
-	rsp_add_test(add)
-	rsp_add_test(sub)
-	rsp_add_test(or)
-	rsp_add_test(and)
-	rsp_add_test(xor)
-	rsp_add_test(nor)
-	rsp_add_test(slt)
-	rsp_add_test(sltu)
-	rsp_add_test(addi)
-	rsp_add_test(slti)
-	rsp_add_test(sltiu)
-	rsp_add_test(andi)
-	rsp_add_test(ori)
-	rsp_add_test(xori)
-	rsp_add_test(lui)
-	rsp_add_test(lb)
-	rsp_add_test(lbu)
-	rsp_add_test(lh)
-	rsp_add_test(lhu)
-	rsp_add_test(lh-unaligned)
-	rsp_add_test(lhu-unaligned)
-	rsp_add_test(lw)
-	rsp_add_test(lw-unaligned)
-	rsp_add_test(sb)
-	rsp_add_test(sh)
-	rsp_add_test(sw)
-	rsp_add_test(sh-unaligned)
-	rsp_add_test(sw-unaligned)
-	rsp_add_test(beq-impossible-delay-slot-second-taken)
-	rsp_add_test(beq-impossible-delay-slot-first-taken)
-	#rsp_add_test(beq-impossible-delay-slot-both-taken) Hangs the reference implementation :D
-	rsp_add_test(bne)
-	rsp_add_test(blez)
-	rsp_add_test(bltz)
-	rsp_add_test(bltzal)
-	rsp_add_test(bgtz)
-	rsp_add_test(bgezal)
-	rsp_add_test(j)
-	rsp_add_test(jal)
-	rsp_add_test(jr)
-	rsp_add_test(jalr)
-	rsp_add_test(lw-unaligned-in-branch-delay)
-	rsp_add_test(delay-slot-before-break)
-	rsp_add_test(delay-slot-before-new-block)
-	rsp_add_test(delay-slot-before-new-block-illegal)
-	rsp_add_test(delay-slot-before-new-block-not-taken)
-	rsp_add_test(unconditional-delay-slot-before-break)
-	rsp_add_test(cop0)
-	rsp_add_test(cop2-basic)
-	rsp_add_test(cop2-ls)
-	rsp_add_test(cop2-vector)
-	rsp_add_test(bug-shl-into-branch)
-endif()
+target_link_libraries(${NAME_PLUGIN_M64P} PUBLIC lightning)

--- a/parallel.cpp
+++ b/parallel.cpp
@@ -4,12 +4,36 @@
 #include "rsp_jit.hpp"
 #endif
 #include <stdint.h>
+#include <cstdarg>
 
 #include "m64p_plugin.h"
 #include "rsp_1.1.h"
 
 #define RSP_PARALLEL_VERSION 0x0101
 #define RSP_PLUGIN_API_VERSION 0x020000
+
+static void (*l_DebugCallback)(void *, int, const char *) = NULL;
+static void *l_DebugCallContext = NULL;
+
+
+#define ATTR_FMT(fmtpos, attrpos) __attribute__ ((format (printf, fmtpos, attrpos)))
+static void DebugMessage(int level, const char *message, ...) ATTR_FMT(2, 3);
+
+void DebugMessage(int level, const char *message, ...)
+{
+    char msgbuf[1024];
+    va_list args;
+
+    if (l_DebugCallback == NULL)
+        return;
+
+    va_start(args, message);
+    vsprintf(msgbuf, message, args);
+
+    (*l_DebugCallback)(l_DebugCallContext, level, msgbuf);
+
+    va_end(args);
+}
 
 namespace RSP
 {
@@ -50,7 +74,7 @@ extern "C"
 	}
 #endif
 
-	EXPORT unsigned int CALL parallelRSPDoRspCycles(unsigned int cycles)
+	EXPORT unsigned int CALL DoRspCycles(unsigned int cycles)
 	{
 		if (*RSP::rsp.SP_STATUS_REG & (SP_STATUS_HALT | SP_STATUS_BROKE))
 			return 0;
@@ -95,7 +119,7 @@ extern "C"
 		return cycles;
 	}
 
-	EXPORT m64p_error CALL parallelRSPPluginGetVersion(m64p_plugin_type *PluginType, int *PluginVersion,
+	EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *PluginVersion,
 	                                                   int *APIVersion, const char **PluginNamePtr, int *Capabilities)
 	{
 		/* set version info */
@@ -114,12 +138,12 @@ extern "C"
 		return M64ERR_SUCCESS;
 	}
 
-	EXPORT void CALL parallelRSPRomClosed(void)
+	EXPORT void CALL RomClosed(void)
 	{
 		*RSP::rsp.SP_PC_REG = 0x00000000;
 	}
 
-	EXPORT void CALL parallelRSPInitiateRSP(RSP_INFO Rsp_Info, unsigned int *CycleCount)
+	EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int *CycleCount)
 	{
 		if (CycleCount)
 			*CycleCount = 0;
@@ -157,5 +181,24 @@ extern "C"
 		RSP::cpu.set_dmem(reinterpret_cast<uint32_t *>(Rsp_Info.DMEM));
 		RSP::cpu.set_imem(reinterpret_cast<uint32_t *>(Rsp_Info.IMEM));
 		RSP::cpu.set_rdram(reinterpret_cast<uint32_t *>(Rsp_Info.RDRAM));
+	}
+
+	EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Context,
+									 void (*DebugCallback)(void *, int, const char *))
+	{
+		/* first thing is to set the callback function for debug info */
+		l_DebugCallback = DebugCallback;
+		l_DebugCallContext = Context;
+		return M64ERR_SUCCESS;
+	}
+
+	EXPORT m64p_error CALL PluginShutdown(void)
+	{
+		return M64ERR_SUCCESS;
+	}
+
+	EXPORT int CALL RomOpen(void)
+	{
+		return 1;
 	}
 }


### PR DESCRIPTION
The folder created for me when working on m64p is `build`, which doesn't match the existing gitignore pattern of `/build-*`. I wasn't sure whether to create this PR here or to Themaister's upstream, since the changes in this fork are to the makefile and might have altered the output directory structure.